### PR TITLE
task-add-student-retrieval

### DIFF
--- a/app/Classes/ResponseHelper.php
+++ b/app/Classes/ResponseHelper.php
@@ -12,15 +12,16 @@ class ResponseHelper
      *
      * @param string $success 'true' | 'false'
      * @param string $status HTTP status code
+     * @param string $version
      * @return array
      */
-    private static function responseHeader($success, $status = '200')
+    private static function responseHeader($success, $status = '200', $version = '1.0')
     {
         return [
             'success' => $success,
             'status' => $status,
             'api' => 'media',
-            'version' => '1.0'
+            'version' => $version
         ];
     }
 
@@ -98,7 +99,7 @@ class ResponseHelper
     public static function customErrorMessage($message)
     {
         $response = self::responseHeader('false', '404');
-        $response['messages'] = $message;
+        $response['messages'] = array($message);
         return $response;
     }
 }

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -46,9 +46,9 @@ class Handler extends ExceptionHandler
      */
     public function render($request, Exception $e)
     {
-        if ($e instanceof HttpException) {
-            return ResponseHelper::error();
-        }
+//        if ($e instanceof HttpException) {
+//            return ResponseHelper::error();
+//        }
         return parent::render($request, $e);
     }
 }

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -3,11 +3,136 @@
 namespace App\Http\Controllers;
 
 use App\Classes\ResponseHelper;
+use GuzzleHttp\Client;
+use GuzzleHttp\Promise\RejectionException;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Storage;
 use Laravel\Lumen\Routing\Controller as BaseController;
 
 class Controller extends BaseController
 {
+
+    /**
+     * Returns the persons media, image and recording
+     *
+     * @param $emailUri
+     * @param $type
+     * @return array
+     */
+    protected function getAllMedia($emailUri, $type)
+    {
+        $recording = $this->getAudioUrl($emailUri, $type);
+        $avatar = $this->getAvatarImageUrl($emailUri, $type);
+        $official = $this->getOfficialImageUrl($emailUri, $type);
+        $response = $this->buildResponse();
+        $response['count'] = strval(count([$avatar, $recording, $official]));
+        $results = [
+            'audio_recording' => $recording,
+            'avatar_image' => $avatar,
+            'official_image' => $official
+        ];
+        if ($type === 'student') {
+            $likeness = [
+                'likeness_image' => $this->getLikenessImageUrl($emailUri, $type)
+            ];
+            $response['count'] = strval(count([$avatar, $recording, $official, $likeness]));
+            $results = array_merge($results, $likeness);
+        }
+        $response['media'][] = $results;
+        return $response;
+    }
+
+    /**
+     * Handles the retrieval of the audio file from the cache
+     *
+     * @param $emailUri
+     * @param $type
+     * @return mixed
+     */
+    protected function getAudioFile($emailUri, $type)
+    {
+        if (Cache::has($emailUri.':audio')) {
+            return redirect(Cache::get($emailUri.':audio'));
+        }
+        $email = $emailUri.'@my.csun.edu';
+
+        if ($type === 'faculty' || $type === 'staff') {
+            $email = $emailUri.'@csun.edu';
+        }
+
+        $url = env('NAMECOACH_API_URL').
+            '?auth_token='.
+            env('NAMECOACH_API_SECRET').
+            '&email_list='.$email;
+        $result = $this->executeGuzzleCall($url);
+        if (!empty($result['data'][0])) {
+            if ($result['data'][0]['recording_link']) {
+                $nameRecording = $result['data'][0]['recording_link'];
+                Cache::add($emailUri.':audio', $nameRecording, env('APP_CACHE_DURATION'));
+                return redirect($nameRecording);
+            }
+        }
+        return ResponseHelper::customErrorMessage('Resource was not found for '.$emailUri);
+    }
+
+    /**
+     * Builds the response JSON header
+     *
+     * @param string $type
+     * @return array
+     */
+    protected function buildResponse($type = 'media')
+    {
+        if ($type === 'error') {
+            $response = [
+                'success' => 'false',
+                'status' => '404',
+                'api' => 'media',
+                'version' => '1.0',
+                'message' => 'Something went wrong with the web service.'
+            ];
+        } else if ($type === 'success') {
+            $response = [
+                'Success' => 'true',
+                'status' => '200',
+                'api' => 'media',
+                'version' => '1.0',
+                'message' => 'Cache deleted successfully.'
+            ];
+        } else {
+            $response = [
+                'success' => 'true',
+                'status' => '200',
+                'api' => 'media',
+                'version' => '1.1',
+                'collection' => $type
+            ];
+        }
+        return $response;
+    }
+
+    /**
+     * Executes the Guzzle call to the APIs
+     *
+     * @param $url
+     * @param $method
+     * @return \Illuminate\Support\Collection|mixed
+     */
+    private function executeGuzzleCall($url)
+    {
+        $options = [
+            'verify' => false
+        ];
+        $client = new Client();
+        try {
+            $response = $client->post($url, $options);
+            $data = json_decode($response->getBody(), true);
+        } catch (RejectionException $e) {
+            $data = $this->buildResponse('error');
+        }
+        return $data;
+    }
+
     /**
      * Handles the retrieval of the image file from the cache
      *
@@ -15,7 +140,7 @@ class Controller extends BaseController
      * @param $type
      * @return mixed
      */
-    public function getAvatarImage($emailUri, $type)
+    protected function getAvatarImage($emailUri, $type)
     {
         $fileDestination = 'media/'.$type.'/'.$emailUri.'/';
         if (Storage::exists($fileDestination.'avatar.jpg')) {
@@ -23,8 +148,6 @@ class Controller extends BaseController
         } else {
            return redirect(env('OFFICIAL_PHOTO_LOCATION'));
         }
-        $response = ResponseHelper::error();
-        return $response;
     }
 
     /**
@@ -34,7 +157,7 @@ class Controller extends BaseController
      * @param $type
      * @return array
      */
-    public function getOfficialImage($emailUri, $type)
+    protected function getOfficialImage($emailUri, $type)
     {
         $fileDestination = 'media/'.$type.'/'.$emailUri.'/';
         if (Storage::exists($fileDestination.'official.jpg')) {
@@ -42,7 +165,77 @@ class Controller extends BaseController
         } else {
             return redirect(env('OFFICIAL_PHOTO_LOCATION'));
         }
-        $response = ResponseHelper::error();
+    }
+
+    /**
+     * @param $emailUri
+     * @param $type
+     * @return array|\Illuminate\Http\RedirectResponse|\Laravel\Lumen\Http\Redirector
+     */
+    protected function getLikenessImage($emailUri, $type)
+    {
+        $fileDestination = 'media/'.$type.'/'.$emailUri.'/';
+        if (Storage::exists($fileDestination.'likeness.jpg')) {
+            return redirect(Storage::url($fileDestination.'likeness.jpg'));
+        } else {
+            return redirect(env('OFFICIAL_PHOTO_LOCATION'));
+        }
+    }
+
+    /**
+     * Returns the individuals audio url
+     *
+     * @param $emailUri
+     * @param $type
+     * @return string
+     */
+    protected function getAudioUrl($emailUri, $type)
+    {
+        return url('/1.1/'.$type.'/media/'.$emailUri.'/audio');
+    }
+
+    /**
+     * Returns the individuals avatar image url
+     *
+     * @param $emailUri
+     * @param $type
+     * @return string
+     */
+    protected function getAvatarImageUrl($emailUri, $type)
+    {
+        return url('/1.1/'.$type.'/media/'.$emailUri.'/avatar');
+    }
+
+    /**
+     * Returns the individuals official image url
+     *
+     * @param $emailUri
+     * @param $type
+     * @return string
+     */
+    protected function getOfficialImageUrl($emailUri, $type)
+    {
+        return url('/1.1/'.$type.'/media/'.$emailUri.'/official');
+    }
+
+    /**
+     * @param $emailUri
+     * @param $type
+     * @return string
+     */
+    protected function getLikenessImageUrl($emailUri, $type)
+    {
+        return url('/1.1/'.$type.'/media/'.$emailUri.'/likeness');
+    }
+
+    /**
+     * Deletes the application cache
+     * @return array
+     */
+    public function clearImageAndAudioFromCache()
+    {
+        Cache::clear();
+        $response = ResponseHelper::cache();
         return $response;
     }
 }

--- a/app/Http/Controllers/FacultyController.php
+++ b/app/Http/Controllers/FacultyController.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Classes\ResponseHelper;
+use GuzzleHttp\Client;
+use GuzzleHttp\Promise\RejectionException;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\Validator;
+
+class FacultyController extends Controller
+{
+
+    /**
+     * @var string
+     */
+    private $mTag;
+
+    /**
+     * FacultyController constructor.
+     */
+    public function __construct()
+    {
+        $this->mTag = 'faculty';
+    }
+
+    /**
+     * Returns the persons media, image and recording
+     *
+     * @param $emailUri
+     * @return array
+     */
+    public function getPersonsMedia($emailUri)
+    {
+        return $this->getAllMedia($emailUri, $this->mTag);
+    }
+
+    /**
+     * Handles the retrieval of the audio file from the cache
+     *
+     * @param $emailUri
+     * @return mixed
+     */
+    public function getAudio($emailUri)
+    {
+        return $this->getAudioFile($emailUri, $this->mTag);
+    }
+
+    /**
+     * Handles the retrieval of the image file from the cache
+     *
+     * @param $emailUri
+     * @return mixed
+     */
+    public function getAvatar($emailUri)
+    {
+        return $this->getAvatarImage($emailUri, $this->mTag);
+    }
+
+    /**
+     * Handles the retrieval of the image file from the mount point.
+     *
+     * @param $emailUri
+     * @return mixed
+     */
+    public function getOfficial($emailUri)
+    {
+        return $this->getOfficialImage($emailUri, $this->mTag);
+    }
+}

--- a/app/Http/Controllers/StaffController.php
+++ b/app/Http/Controllers/StaffController.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Classes\ResponseHelper;
+use GuzzleHttp\Client;
+use GuzzleHttp\Promise\RejectionException;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\Validator;
+
+class StaffController extends Controller
+{
+
+    /**
+     * @var string
+     */
+    private $mTag;
+
+    /**
+     * StaffController constructor.
+     */
+    public function __construct()
+    {
+        $this->mTag = 'staff';
+    }
+
+    /**
+     * Returns the persons media, image and recording
+     *
+     * @param $emailUri
+     * @return array
+     */
+    public function getPersonsMedia($emailUri)
+    {
+        return $this->getAllMedia($emailUri, $this->mTag);
+    }
+
+    /**
+     * Handles the retrieval of the audio file from the cache
+     *
+     * @param $emailUri
+     * @return mixed
+     */
+    public function getAudio($emailUri)
+    {
+        return $this->getAudioFile($emailUri, $this->mTag);
+    }
+
+    /**
+     * Handles the retrieval of the image file from the cache
+     *
+     * @param $emailUri
+     * @return mixed
+     */
+    public function getAvatar($emailUri)
+    {
+        return $this->getAvatarImage($emailUri, $this->mTag);
+    }
+
+    /**
+     * Handles the retrieval of the image file from the mount point.
+     *
+     * @param $emailUri
+     * @return mixed
+     */
+    public function getOfficial($emailUri)
+    {
+        return $this->getOfficialImage($emailUri, $this->mTag);
+    }
+
+}

--- a/app/Http/Controllers/StudentController.php
+++ b/app/Http/Controllers/StudentController.php
@@ -69,4 +69,15 @@ class StudentController extends Controller
     {
         return $this->getOfficialImage($emailUri, $this->mTag);
     }
+
+    /**
+     * Handles the retrieval of the image file from the mount point.
+     *
+     * @param $emailUri
+     * @return mixed
+     */
+    public function getLikeness($emailUri)
+    {
+        return $this->getLikenessImage($emailUri, $this->mTag);
+    }
 }

--- a/app/Http/Controllers/StudentController.php
+++ b/app/Http/Controllers/StudentController.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Classes\ResponseHelper;
+use GuzzleHttp\Client;
+use GuzzleHttp\Promise\RejectionException;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\Validator;
+
+class StudentController extends Controller
+{
+
+    /**
+     * @var string
+     */
+    private $mTag;
+
+    /**
+     * StudentController constructor.
+     */
+    public function __construct()
+    {
+        $this->mTag = 'student';
+    }
+
+    /**
+     * Returns the persons media, image and recording
+     *
+     * @param $emailUri
+     * @return array
+     */
+    public function getPersonsMedia($emailUri)
+    {
+        return $this->getAllMedia($emailUri, $this->mTag);
+    }
+
+    /**
+     * Handles the retrieval of the audio file from the cache
+     *
+     * @param $emailUri
+     * @return mixed
+     */
+    public function getAudio($emailUri)
+    {
+        return $this->getAudioFile($emailUri, $this->mTag);
+    }
+
+    /**
+     * Handles the retrieval of the image file from the cache
+     *
+     * @param $emailUri
+     * @return mixed
+     */
+    public function getAvatar($emailUri)
+    {
+        return $this->getAvatarImage($emailUri, $this->mTag);
+    }
+
+    /**
+     * Handles the retrieval of the image file from the mount point.
+     *
+     * @param $emailUri
+     * @return mixed
+     */
+    public function getOfficial($emailUri)
+    {
+        return $this->getOfficialImage($emailUri, $this->mTag);
+    }
+}

--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -19,13 +19,13 @@ class Authenticate
         if($request->has('secret_key') && $request->get('secret_key') === env('SECRET_KEY')) {
             return $next($request);
         } else {
-            return [
+            return response()->json([
                 'success' => 'false',
                 'status' => '404',
                 'api' => 'media',
                 'version' => '1.0',
                 'message' => 'Please check your API key.'
-            ];
+            ]);
         }
     }
 }

--- a/routes/1.0.php
+++ b/routes/1.0.php
@@ -1,8 +1,6 @@
 <?php
 
-$router->group(['prefix' => '/faculty/media'], function () use ($router) {
-    $router->get('/{emailUri}/avatar-image', 'MediaController@getPersonsImage');
-    $router->get('/{emailUri}/audio-recording', 'MediaController@getPersonsAudio');
-    $router->get('/{emailUri}/photo-id-image', 'MediaController@getPersonsOfficialImage');
-    $router->get('/{emailUri}', 'MediaController@getPersonsMedia');
-});
+$router->get('/faculty/media/{emailUri}', 'MediaController@getPersonsMedia');
+$router->get('/{emailUri}/avatar', 'MediaController@getPersonsAvatarImage');
+$router->get('/{emailUri}/audio', 'MediaController@getPersonsAudio');
+$router->get('/{emailUri}/official', 'MediaController@getPersonsOfficialImage');

--- a/routes/1.1.php
+++ b/routes/1.1.php
@@ -6,6 +6,7 @@ $router->group(['prefix' => 'student/media'], function () use ($router) {
     $router->get('/{emailUri}/avatar', 'StudentController@getAvatar');
     $router->get('/{emailUri}/audio', 'StudentController@getAudio');
     $router->get('/{emailUri}/official', 'StudentController@getOfficial');
+    $router->get('/{emailUri}/likeness', 'StudentController@getOfficial');
     $router->get('/{emailUri}', 'StudentController@getPersonsMedia');
 });
 

--- a/routes/1.1.php
+++ b/routes/1.1.php
@@ -1,3 +1,24 @@
 <?php
 
 $router->post('/{emailUri}/photo', 'MediaController@storeImage');
+
+$router->group(['prefix' => 'student/media'], function () use ($router) {
+    $router->get('/{emailUri}/avatar', 'StudentController@getAvatar');
+    $router->get('/{emailUri}/audio', 'StudentController@getAudio');
+    $router->get('/{emailUri}/official', 'StudentController@getOfficial');
+    $router->get('/{emailUri}', 'StudentController@getPersonsMedia');
+});
+
+$router->group(['prefix' => 'staff/media'], function () use ($router) {
+    $router->get('/{emailUri}/avatar', 'StaffController@getAvatar');
+    $router->get('/{emailUri}/audio', 'StaffController@getAudio');
+    $router->get('/{emailUri}/official', 'StaffController@getOfficial');
+    $router->get('/{emailUri}', 'StaffController@getPersonsMedia');
+});
+
+$router->group(['prefix' => 'faculty/media'], function () use ($router) {
+    $router->get('/{emailUri}/avatar', 'FacultyController@getAvatar');
+    $router->get('/{emailUri}/audio', 'FacultyController@getAudio');
+    $router->get('/{emailUri}/official', 'FacultyController@getOfficial');
+    $router->get('/{emailUri}', 'FacultyController@getPersonsMedia');
+});

--- a/routes/api.php
+++ b/routes/api.php
@@ -11,8 +11,8 @@
 |
 */
 $router->group(['prefix' => '1.0'], function () use($router) {
-    $router->get('/{emailUri}/avatar-image', 'MediaController@getPersonsAvatarImage');
-    $router->get('/{emailUri}/audio-recording', 'MediaController@getPersonsAudio');
-    $router->get('/{emailUri}/photo-id-image', 'MediaController@getPersonsOfficialImage');
+    $router->get('/{emailUri}/avatar', 'MediaController@getPersonsAvatarImage');
+    $router->get('/{emailUri}/audio', 'MediaController@getPersonsAudio');
+    $router->get('/{emailUri}/official', 'MediaController@getPersonsOfficialImage');
     $router->get('/faculty/media/{emailUri}', 'MediaController@getPersonsMedia');
 });


### PR DESCRIPTION
# Summary
This pull request Includes the changes made for the student retrieval, staff retrieval and faculty retrieval.

# To Test
There are new routes made the old functionality with the `1.0` and `api/1.0` behave the exact same way. The new routes to test are the following:
+ `1.1/faculty/media/<emailUri>`
+ `1.1/staff/media/<emailUri>`
+ `1.1/student/media/<emailUri>`

Each route should generate a JSON with 3 additional routes except for the student look-up with returns a 4th item.
